### PR TITLE
feat: implement `-context-only`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ The linter has several options, so you can adjust it to your own code style.
 
 * Forbid mixing key-value pairs and attributes within a single function call (default)
 * Enforce using either key-value pairs or attributes for the entire project (optional)
+* Enforce using methods that accept a context (optional)
 * Enforce using constants instead of raw keys (optional)
 * Enforce putting arguments on separate lines (optional)
-* Enforce using methods that take a context (optional)
 
 ## 📦 Install
 
@@ -52,6 +52,22 @@ In contrast, the `-attr-only` flag causes `sloglint` to report any use of key-va
 
 ```go
 slog.Info("a user has logged in", "user_id", 42) // sloglint: key-value pairs should not be used
+```
+
+### Context only
+
+Some `slog.Handler` implementations make use of the given `context.Context` (e.g. to access context values).
+For them to work properly, you need to pass a context to all logger calls.
+The `-context-only` flag causes `sloglint` to report the use of methods without a context.
+
+```go
+slog.Info("a user has logged in") // sloglint: methods without a context should not be used
+```
+
+This report can be fixed by using the equivalent method with the `Context` suffix.
+
+```go
+slog.InfoContext(ctx, "a user has logged in")
 ```
 
 ### No raw keys
@@ -98,23 +114,6 @@ slog.Info("a user has logged in",
     "ip_address", "192.0.2.0",
 )
 ```
-
-### Context only
-
-The `-context-only` flag causes `sloglint` to report the use of any methods that do not take a `context.Context`.
-
-```go
-slog.Info("a user has logged in") // sloglint: methods without a context should not be used
-```
-
-This report can be fixed by using the equivalent method with a `Context` suffix.
-
-```go
-slog.InfoContext(ctx, "a user has logged in")
-```
-
-The `slog.Handler` implementations in the standard library do not currently utilise the given
-context. However, third-party implementations can create `slog.Attr` instances from the context.
 
 [1]: https://github.com/go-simpler/sloglint/releases
 [2]: https://github.com/go-simpler/sloggen

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ slog.Info("a user has logged in",
 The `-context-only` flag causes `sloglint` to report the use of any methods that do not take a `context.Context`.
 
 ```go
-slog.Info("a user has logged in") // sloglint: methods that do not take a context should not be used"
+slog.Info("a user has logged in") // sloglint: methods without a context should not be used
 ```
 
 This report can be fixed by using the equivalent method with a `Context` suffix.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The linter has several options, so you can adjust it to your own code style.
 * Enforce using either key-value pairs or attributes for the entire project (optional)
 * Enforce using constants instead of raw keys (optional)
 * Enforce putting arguments on separate lines (optional)
+* Enforce using methods that take a context (optional)
 
 ## 📦 Install
 
@@ -97,6 +98,23 @@ slog.Info("a user has logged in",
     "ip_address", "192.0.2.0",
 )
 ```
+
+### Context only
+
+The `-context-only` flag causes `sloglint` to report the use of any methods that do not take a `context.Context`.
+
+```go
+slog.Info("a user has logged in") // sloglint: methods that do not take a context should not be used"
+```
+
+This report can be fixed by using the equivalent method with a `Context` suffix.
+
+```go
+slog.InfoContext(ctx, "a user has logged in")
+```
+
+The `slog.Handler` implementations in the standard library do not currently utilise the given
+context. However, third-party implementations can create `slog.Attr` instances from the context.
 
 [1]: https://github.com/go-simpler/sloglint/releases
 [2]: https://github.com/go-simpler/sloggen

--- a/sloglint.go
+++ b/sloglint.go
@@ -19,9 +19,9 @@ import (
 type Options struct {
 	KVOnly         bool // Enforce using key-value pairs only (incompatible with AttrOnly).
 	AttrOnly       bool // Enforce using attributes only (incompatible with KVOnly).
+	ContextOnly    bool // Enforce using methods that accept a context.
 	NoRawKeys      bool // Enforce using constants instead of raw keys.
 	ArgsOnSepLines bool // Enforce putting arguments on separate lines.
-	ContextOnly    bool // Enforce using methods that take a context.
 }
 
 // New creates a new sloglint analyzer.
@@ -57,9 +57,9 @@ func flags(opts *Options) flag.FlagSet {
 
 	boolVar(&opts.KVOnly, "kv-only", "enforce using key-value pairs only (incompatible with -attr-only)")
 	boolVar(&opts.AttrOnly, "attr-only", "enforce using attributes only (incompatible with -kv-only)")
+	boolVar(&opts.ContextOnly, "context-only", "enforce using methods that accept a context")
 	boolVar(&opts.NoRawKeys, "no-raw-keys", "enforce using constants instead of raw keys")
 	boolVar(&opts.ArgsOnSepLines, "args-on-sep-lines", "enforce putting arguments on separate lines")
-	boolVar(&opts.ContextOnly, "context-only", "enforce using methods that take a context")
 
 	return *fs
 }

--- a/sloglint.go
+++ b/sloglint.go
@@ -116,9 +116,9 @@ func run(pass *analysis.Pass, opts *Options) {
 		}
 
 		if opts.ContextOnly {
-			arg, ok := pass.TypesInfo.Types[call.Args[0]]
-			if ok && arg.Type.String() != "context.Context" {
-				pass.Reportf(call.Pos(), "methods that do not take a context should not be used")
+			arg := pass.TypesInfo.TypeOf(call.Args[0])
+			if arg != nil && arg.String() != "context.Context" {
+				pass.Reportf(call.Pos(), "methods without a context should not be used")
 			}
 		}
 

--- a/sloglint.go
+++ b/sloglint.go
@@ -116,8 +116,8 @@ func run(pass *analysis.Pass, opts *Options) {
 		}
 
 		if opts.ContextOnly {
-			arg := pass.TypesInfo.TypeOf(call.Args[0])
-			if arg != nil && arg.String() != "context.Context" {
+			typ := pass.TypesInfo.TypeOf(call.Args[0])
+			if typ != nil && typ.String() != "context.Context" {
 				pass.Reportf(call.Pos(), "methods without a context should not be used")
 			}
 		}

--- a/sloglint_test.go
+++ b/sloglint_test.go
@@ -25,6 +25,11 @@ func TestAnalyzer(t *testing.T) {
 		analysistest.Run(t, testdata, analyzer, "attr_only")
 	})
 
+	t.Run("context only", func(t *testing.T) {
+		analyzer := sloglint.New(&sloglint.Options{ContextOnly: true})
+		analysistest.Run(t, testdata, analyzer, "context_only")
+	})
+
 	t.Run("no raw keys", func(t *testing.T) {
 		analyzer := sloglint.New(&sloglint.Options{NoRawKeys: true})
 		analysistest.Run(t, testdata, analyzer, "no_raw_keys")
@@ -33,10 +38,5 @@ func TestAnalyzer(t *testing.T) {
 	t.Run("arguments on separate lines", func(t *testing.T) {
 		analyzer := sloglint.New(&sloglint.Options{ArgsOnSepLines: true})
 		analysistest.Run(t, testdata, analyzer, "args_on_sep_lines")
-	})
-
-	t.Run("context only", func(t *testing.T) {
-		analyzer := sloglint.New(&sloglint.Options{ContextOnly: true})
-		analysistest.Run(t, testdata, analyzer, "context_only")
 	})
 }

--- a/sloglint_test.go
+++ b/sloglint_test.go
@@ -34,4 +34,9 @@ func TestAnalyzer(t *testing.T) {
 		analyzer := sloglint.New(&sloglint.Options{ArgsOnSepLines: true})
 		analysistest.Run(t, testdata, analyzer, "args_on_sep_lines")
 	})
+
+	t.Run("context only", func(t *testing.T) {
+		analyzer := sloglint.New(&sloglint.Options{ContextOnly: true})
+		analysistest.Run(t, testdata, analyzer, "context_only")
+	})
 }

--- a/testdata/src/context_only/context_only.go
+++ b/testdata/src/context_only/context_only.go
@@ -2,34 +2,32 @@ package context_only
 
 import (
 	"context"
-	"io"
 	"log/slog"
 )
 
 func tests() {
+	logger := slog.New(nil)
 	ctx := context.Background()
 
-	slog.Debug("msg") // want `methods that do not take a context should not be used`
-	slog.Info("msg")  // want `methods that do not take a context should not be used`
-	slog.Warn("msg")  // want `methods that do not take a context should not be used`
-	slog.Error("msg") // want `methods that do not take a context should not be used`
-
-	slog.Log(context.Background(), slog.LevelInfo, "msg")
-	slog.DebugContext(context.TODO(), "msg")
-	slog.InfoContext(context.WithoutCancel(ctx), "msg")
+	slog.Log(ctx, slog.LevelInfo, "msg")
+	slog.DebugContext(ctx, "msg")
+	slog.InfoContext(ctx, "msg")
 	slog.WarnContext(ctx, "msg")
 	slog.ErrorContext(ctx, "msg")
-
-	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
-
-	logger.Debug("msg") // want `methods that do not take a context should not be used`
-	logger.Info("msg")  // want `methods that do not take a context should not be used`
-	logger.Warn("msg")  // want `methods that do not take a context should not be used`
-	logger.Error("msg") // want `methods that do not take a context should not be used`
 
 	logger.Log(ctx, slog.LevelInfo, "msg")
 	logger.DebugContext(ctx, "msg")
 	logger.InfoContext(ctx, "msg")
 	logger.WarnContext(ctx, "msg")
 	logger.ErrorContext(ctx, "msg")
+
+	slog.Debug("msg") // want `methods without a context should not be used`
+	slog.Info("msg")  // want `methods without a context should not be used`
+	slog.Warn("msg")  // want `methods without a context should not be used`
+	slog.Error("msg") // want `methods without a context should not be used`
+
+	logger.Debug("msg") // want `methods without a context should not be used`
+	logger.Info("msg")  // want `methods without a context should not be used`
+	logger.Warn("msg")  // want `methods without a context should not be used`
+	logger.Error("msg") // want `methods without a context should not be used`
 }

--- a/testdata/src/context_only/context_only.go
+++ b/testdata/src/context_only/context_only.go
@@ -1,0 +1,35 @@
+package context_only
+
+import (
+	"context"
+	"io"
+	"log/slog"
+)
+
+func tests() {
+	ctx := context.Background()
+
+	slog.Debug("msg") // want `methods that do not take a context should not be used`
+	slog.Info("msg")  // want `methods that do not take a context should not be used`
+	slog.Warn("msg")  // want `methods that do not take a context should not be used`
+	slog.Error("msg") // want `methods that do not take a context should not be used`
+
+	slog.Log(context.Background(), slog.LevelInfo, "msg")
+	slog.DebugContext(context.TODO(), "msg")
+	slog.InfoContext(context.WithoutCancel(ctx), "msg")
+	slog.WarnContext(ctx, "msg")
+	slog.ErrorContext(ctx, "msg")
+
+	logger := slog.New(slog.NewJSONHandler(io.Discard, &slog.HandlerOptions{}))
+
+	logger.Debug("msg") // want `methods that do not take a context should not be used`
+	logger.Info("msg")  // want `methods that do not take a context should not be used`
+	logger.Warn("msg")  // want `methods that do not take a context should not be used`
+	logger.Error("msg") // want `methods that do not take a context should not be used`
+
+	logger.Log(ctx, slog.LevelInfo, "msg")
+	logger.DebugContext(ctx, "msg")
+	logger.InfoContext(ctx, "msg")
+	logger.WarnContext(ctx, "msg")
+	logger.ErrorContext(ctx, "msg")
+}


### PR DESCRIPTION
As described in #13, third-party implementations of `slog.Handler` can choose to take values out of a context to supplement the attributes already used. An example of this in my day job is adding trace IDs to enhance serviceability.

This change adds the ability to optionally identify `slog` methods that do not take a context and so prevent the ability to take values from that context. Any matches can be resolved by appending `Context` to the method. For example, `slog.Info` becomes `slog.Context`.