### PR TITLE
feat: implement `-static-msg`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The linter has several options, so you can adjust it to your own code style.
 * Enforce using either key-value pairs or attributes for the entire project (optional)
 * Enforce using methods that accept a context (optional)
 * Enforce using constants instead of raw keys (optional)
+* Enforce using static values for log messages (optional)
 * Enforce a single key naming convention (optional)
 * Enforce putting arguments on separate lines (optional)
 
@@ -109,6 +110,29 @@ slog.Info("a user has logged in", UserId(42))
 ```
 
 > 💡 Such helpers can be automatically generated for you by the [`sloggen`][4] tool. Give it a try too!
+
+### Static messages
+
+To maximise the utility of structured logging, you may want to require log messages are static and
+move dynamic values to attributes. The `static-msg` option causes `sloglint` to report log messages
+that are not string literals or constants:
+
+```go
+myMsg := generateMsg()
+slog.Info(myMsg) // sloglint: messages should be string literals or constants
+
+slog.Info(fmt.Sprintf("message: %s", value)) // sloglint: messages should be string literals or constants
+```
+
+The report can be fixed by moving any dynamic values to attributes and useing a constant or a string
+literal for the message:
+
+```go
+const myMsg = "message"
+slog.Info(myMsg)
+
+slog.Info("message", slog.String("value", value))
+```
 
 ### Key naming convention
 

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ The linter has several options, so you can adjust it to your own code style.
 * Forbid mixing key-value pairs and attributes within a single function call (default)
 * Enforce using either key-value pairs or attributes for the entire project (optional)
 * Enforce using methods that accept a context (optional)
+* Enforce using static log messages (optional)
 * Enforce using constants instead of raw keys (optional)
-* Enforce using static values for log messages (optional)
 * Enforce a single key naming convention (optional)
 * Enforce putting arguments on separate lines (optional)
 
@@ -83,6 +83,21 @@ This report can be fixed by using the equivalent method with the `Context` suffi
 slog.InfoContext(ctx, "a user has logged in")
 ```
 
+### Static messages
+
+To get the most out of structured logging, you may want to require log messages to be static.
+The `static-msg` option causes `sloglint` to report non-static messages:
+
+```go
+slog.Info(fmt.Sprintf("a user with id %d has logged in", 42)) // sloglint: message should be a string literal or a constant
+```
+
+The report can be fixed by moving dynamic values to arguments:
+
+```go
+slog.Info("a user has logged in", "user_id", 42)
+```
+
 ### No raw keys
 
 To prevent typos, you may want to forbid the use of raw keys altogether.
@@ -110,29 +125,6 @@ slog.Info("a user has logged in", UserId(42))
 ```
 
 > 💡 Such helpers can be automatically generated for you by the [`sloggen`][4] tool. Give it a try too!
-
-### Static messages
-
-To maximise the utility of structured logging, you may want to require log messages are static and
-move dynamic values to attributes. The `static-msg` option causes `sloglint` to report log messages
-that are not string literals or constants:
-
-```go
-myMsg := generateMsg()
-slog.Info(myMsg) // sloglint: messages should be string literals or constants
-
-slog.Info(fmt.Sprintf("message: %s", value)) // sloglint: messages should be string literals or constants
-```
-
-The report can be fixed by moving any dynamic values to attributes and useing a constant or a string
-literal for the message:
-
-```go
-const myMsg = "message"
-slog.Info(myMsg)
-
-slog.Info("message", slog.String("value", value))
-```
 
 ### Key naming convention
 

--- a/sloglint.go
+++ b/sloglint.go
@@ -23,6 +23,7 @@ type Options struct {
 	AttrOnly       bool   // Enforce using attributes only (incompatible with KVOnly).
 	ContextOnly    bool   // Enforce using methods that accept a context.
 	NoRawKeys      bool   // Enforce using constants instead of raw keys.
+	StaticMsg      bool   // Enforce using static values for messages.
 	KeyNamingCase  string // Enforce a single key naming convention ("snake", "kebab", "camel", or "pascal").
 	ArgsOnSepLines bool   // Enforce putting arguments on separate lines.
 }
@@ -71,6 +72,7 @@ func flags(opts *Options) flag.FlagSet {
 	boolVar(&opts.KVOnly, "kv-only", "enforce using key-value pairs only (incompatible with -attr-only)")
 	boolVar(&opts.AttrOnly, "attr-only", "enforce using attributes only (incompatible with -kv-only)")
 	boolVar(&opts.ContextOnly, "context-only", "enforce using methods that accept a context")
+	boolVar(&opts.StaticMsg, "static-msg", "enforce using static values for messages")
 	boolVar(&opts.NoRawKeys, "no-raw-keys", "enforce using constants instead of raw keys")
 	boolVar(&opts.ArgsOnSepLines, "args-on-sep-lines", "enforce putting arguments on separate lines")
 
@@ -147,6 +149,10 @@ func run(pass *analysis.Pass, opts *Options) {
 			}
 		}
 
+		if opts.StaticMsg && !isStaticMsg(call.Args[argsPos-1]) {
+			pass.Reportf(call.Pos(), "messages should be string literals or constants")
+		}
+
 		// NOTE: we assume that the arguments have already been validated by govet.
 		args := call.Args[argsPos:]
 		if len(args) == 0 {
@@ -197,6 +203,17 @@ func run(pass *analysis.Pass, opts *Options) {
 			pass.Reportf(call.Pos(), "keys should be written in PascalCase")
 		}
 	})
+}
+
+func isStaticMsg(arg ast.Expr) bool {
+	switch val := arg.(type) {
+	case *ast.BasicLit:
+		return true
+	case *ast.Ident:
+		return val.Obj != nil && val.Obj.Kind == ast.Con
+	default:
+		return false
+	}
 }
 
 func rawKeysUsed(info *types.Info, keys, attrs []ast.Expr) bool {

--- a/sloglint_test.go
+++ b/sloglint_test.go
@@ -35,6 +35,11 @@ func TestAnalyzer(t *testing.T) {
 		analysistest.Run(t, testdata, analyzer, "no_raw_keys")
 	})
 
+	t.Run("static msg", func(t *testing.T) {
+		analyzer := sloglint.New(&sloglint.Options{StaticMsg: true})
+		analysistest.Run(t, testdata, analyzer, "static_msg")
+	})
+
 	t.Run("key naming case", func(t *testing.T) {
 		analyzer := sloglint.New(&sloglint.Options{KeyNamingCase: "snake"})
 		analysistest.Run(t, testdata, analyzer, "key_naming_case")

--- a/sloglint_test.go
+++ b/sloglint_test.go
@@ -30,14 +30,14 @@ func TestAnalyzer(t *testing.T) {
 		analysistest.Run(t, testdata, analyzer, "context_only")
 	})
 
+	t.Run("static message", func(t *testing.T) {
+		analyzer := sloglint.New(&sloglint.Options{StaticMsg: true})
+		analysistest.Run(t, testdata, analyzer, "static_msg")
+	})
+
 	t.Run("no raw keys", func(t *testing.T) {
 		analyzer := sloglint.New(&sloglint.Options{NoRawKeys: true})
 		analysistest.Run(t, testdata, analyzer, "no_raw_keys")
-	})
-
-	t.Run("static msg", func(t *testing.T) {
-		analyzer := sloglint.New(&sloglint.Options{StaticMsg: true})
-		analysistest.Run(t, testdata, analyzer, "static_msg")
 	})
 
 	t.Run("key naming case", func(t *testing.T) {

--- a/testdata/src/static_msg/static_msg.go
+++ b/testdata/src/static_msg/static_msg.go
@@ -13,19 +13,19 @@ var varMsg = "msg"
 func tests() {
 	ctx := context.Background()
 
+	slog.Info("msg")
+	slog.InfoContext(ctx, "msg")
 	slog.Log(ctx, slog.LevelInfo, "msg")
-	slog.Debug("msg")
-	slog.DebugContext(ctx, "msg")
 
+	slog.Info(constMsg)
+	slog.InfoContext(ctx, constMsg)
 	slog.Log(ctx, slog.LevelInfo, constMsg)
-	slog.Debug(constMsg)
-	slog.DebugContext(ctx, constMsg)
 
-	slog.Log(ctx, slog.LevelInfo, fmt.Sprintf("msg")) // want `messages should be string literals or constants`
-	slog.Debug(fmt.Sprintf("msg"))                    // want `messages should be string literals or constants`
-	slog.DebugContext(ctx, fmt.Sprintf("msg"))        // want `messages should be string literals or constants`
+	slog.Info(fmt.Sprintf("msg"))                     // want `message should be a string literal or a constant`
+	slog.InfoContext(ctx, fmt.Sprintf("msg"))         // want `message should be a string literal or a constant`
+	slog.Log(ctx, slog.LevelInfo, fmt.Sprintf("msg")) // want `message should be a string literal or a constant`
 
-	slog.Log(ctx, slog.LevelInfo, varMsg) // want `messages should be string literals or constants`
-	slog.Debug(varMsg)                    // want `messages should be string literals or constants`
-	slog.DebugContext(ctx, varMsg)        // want `messages should be string literals or constants`
+	slog.Info(varMsg)                     // want `message should be a string literal or a constant`
+	slog.InfoContext(ctx, varMsg)         // want `message should be a string literal or a constant`
+	slog.Log(ctx, slog.LevelInfo, varMsg) // want `message should be a string literal or a constant`
 }

--- a/testdata/src/static_msg/static_msg.go
+++ b/testdata/src/static_msg/static_msg.go
@@ -1,0 +1,31 @@
+package static_msg
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+)
+
+const constMsg = "msg"
+
+var varMsg = "msg"
+
+func tests() {
+	ctx := context.Background()
+
+	slog.Log(ctx, slog.LevelInfo, "msg")
+	slog.Debug("msg")
+	slog.DebugContext(ctx, "msg")
+
+	slog.Log(ctx, slog.LevelInfo, constMsg)
+	slog.Debug(constMsg)
+	slog.DebugContext(ctx, constMsg)
+
+	slog.Log(ctx, slog.LevelInfo, fmt.Sprintf("msg")) // want `messages should be string literals or constants`
+	slog.Debug(fmt.Sprintf("msg"))                    // want `messages should be string literals or constants`
+	slog.DebugContext(ctx, fmt.Sprintf("msg"))        // want `messages should be string literals or constants`
+
+	slog.Log(ctx, slog.LevelInfo, varMsg) // want `messages should be string literals or constants`
+	slog.Debug(varMsg)                    // want `messages should be string literals or constants`
+	slog.DebugContext(ctx, varMsg)        // want `messages should be string literals or constants`
+}


### PR DESCRIPTION
This adds support for enforcing log messages are static by requiring the use of string literals or constants.

Fixes #17.