### PR TITLE
feat: support `With` and  `LogAttrs` functions

### DIFF
--- a/sloglint.go
+++ b/sloglint.go
@@ -114,12 +114,11 @@ func flags(opts *Options) flag.FlagSet {
 	return *fset
 }
 
-type slogFuncInfo struct {
+var slogFuncs = map[string]struct {
 	argsPos          int
 	skipContextCheck bool
-}
-
-var slogFuncs = map[string]slogFuncInfo{ // funcName:
+}{
+	// funcName: {argsPos, skipContextCheck}
 	"log/slog.With":                   {argsPos: 0, skipContextCheck: true},
 	"log/slog.Log":                    {argsPos: 3},
 	"log/slog.LogAttrs":               {argsPos: 3},
@@ -208,7 +207,7 @@ func visit(pass *analysis.Pass, opts *Options, node ast.Node, stack []ast.Node) 
 		}
 	}
 
-	// NOTE: with functions are not checked for context.Context.
+	// NOTE: "With" functions are not checked for context.Context.
 	if !funcInfo.skipContextCheck {
 		switch opts.ContextOnly {
 		case "all":

--- a/testdata/src/args_on_sep_lines/args_on_sep_lines.go
+++ b/testdata/src/args_on_sep_lines/args_on_sep_lines.go
@@ -16,6 +16,16 @@ func tests() {
 		slog.Int("bar", 2),
 	)
 
+	slog.With(
+		"foo", 1,
+		"bar", 2,
+	).Info("msg")
+
+	slog.With(
+		slog.Int("foo", 1),
+		slog.Int("bar", 2),
+	).Info("msg")
+
 	slog.Info("msg", "foo", 1, "bar", 2)                     // want `arguments should be put on separate lines`
 	slog.Info("msg", slog.Int("foo", 1), slog.Int("bar", 2)) // want `arguments should be put on separate lines`
 
@@ -31,4 +41,7 @@ func tests() {
 	slog.Info("msg", // want `arguments should be put on separate lines`
 		slog.Int("foo", 1), slog.Int("bar", 2),
 	)
+
+	slog.With("msg", "foo", 1, "bar", 2).Info("msg")                     // want `arguments should be put on separate lines`
+	slog.With("msg", slog.Int("foo", 1), slog.Int("bar", 2)).Info("msg") // want `arguments should be put on separate lines`
 }

--- a/testdata/src/attr_only/attr_only.go
+++ b/testdata/src/attr_only/attr_only.go
@@ -6,8 +6,10 @@ func tests() {
 	slog.Info("msg")
 	slog.Info("msg", slog.Int("foo", 1))
 	slog.Info("msg", slog.Int("foo", 1), slog.Int("bar", 2))
+	slog.With(slog.Int("foo", 1), slog.Int("bar", 2)).Info("msg")
 
-	slog.Info("msg", "foo", 1)                     // want `key-value pairs should not be used`
-	slog.Info("msg", "foo", 1, "bar", 2)           // want `key-value pairs should not be used`
-	slog.Info("msg", "foo", 1, slog.Int("bar", 2)) // want `key-value pairs should not be used`
+	slog.Info("msg", "foo", 1)                          // want `key-value pairs should not be used`
+	slog.Info("msg", "foo", 1, "bar", 2)                // want `key-value pairs should not be used`
+	slog.Info("msg", "foo", 1, slog.Int("bar", 2))      // want `key-value pairs should not be used`
+	slog.With("foo", 1, slog.Int("bar", 2)).Info("msg") // want `key-value pairs should not be used`
 }

--- a/testdata/src/context_only_all/context_only_all.go
+++ b/testdata/src/context_only_all/context_only_all.go
@@ -11,6 +11,7 @@ func tests(ctx context.Context) {
 	slog.InfoContext(ctx, "msg")
 	slog.WarnContext(ctx, "msg")
 	slog.ErrorContext(ctx, "msg")
+	slog.With("key", "value").ErrorContext(ctx, "msg")
 
 	slog.Debug("msg") // want `DebugContext should be used instead`
 	slog.Info("msg")  // want `InfoContext should be used instead`
@@ -24,8 +25,9 @@ func tests(ctx context.Context) {
 	logger.WarnContext(ctx, "msg")
 	logger.ErrorContext(ctx, "msg")
 
-	logger.Debug("msg") // want `DebugContext should be used instead`
-	logger.Info("msg")  // want `InfoContext should be used instead`
-	logger.Warn("msg")  // want `WarnContext should be used instead`
-	logger.Error("msg") // want `ErrorContext should be used instead`
+	logger.Debug("msg")                      // want `DebugContext should be used instead`
+	logger.Info("msg")                       // want `InfoContext should be used instead`
+	logger.Warn("msg")                       // want `WarnContext should be used instead`
+	logger.Error("msg")                      // want `ErrorContext should be used instead`
+	logger.With("key", "value").Error("msg") // want `ErrorContext should be used instead`
 }

--- a/testdata/src/forbidden_keys/forbidden_keys.go
+++ b/testdata/src/forbidden_keys/forbidden_keys.go
@@ -9,18 +9,29 @@ const (
 func tests() {
 	slog.Info("msg")
 	slog.Info("msg", "foo-bar", 1)
+	slog.With("foo-bar", 1).Info("msg")
 	slog.Info("msg", "foo_bar", 1)           // want `"foo_bar" key is forbidden and should not be used`
 	slog.Info("msg", snakeKey, 1)            // want `"foo_bar" key is forbidden and should not be used`
 	slog.Info("msg", slog.Int("foo_bar", 1)) // want `"foo_bar" key is forbidden and should not be used`
 	slog.Info("msg", slog.Int(snakeKey, 1))  // want `"foo_bar" key is forbidden and should not be used`
 	slog.Info("msg", slog.Attr{})
-	slog.Info("msg", slog.Attr{"foo_bar", slog.IntValue(1)})             // want `"foo_bar" key is forbidden and should not be used`
-	slog.Info("msg", slog.Attr{snakeKey, slog.IntValue(1)})              // want `"foo_bar" key is forbidden and should not be used`
-	slog.Info("msg", slog.Attr{Key: "foo_bar"})                          // want `"foo_bar" key is forbidden and should not be used`
-	slog.Info("msg", slog.Attr{Key: snakeKey})                           // want `"foo_bar" key is forbidden and should not be used`
-	slog.Info("msg", slog.Attr{Key: "foo_bar", Value: slog.IntValue(1)}) // want `"foo_bar" key is forbidden and should not be used`
-	slog.Info("msg", slog.Attr{Key: snakeKey, Value: slog.IntValue(1)})  // want `"foo_bar" key is forbidden and should not be used`
-	slog.Info("msg", slog.Attr{Value: slog.IntValue(1), Key: "foo_bar"}) // want `"foo_bar" key is forbidden and should not be used`
-	slog.Info("msg", slog.Attr{Value: slog.IntValue(1), Key: snakeKey})  // want `"foo_bar" key is forbidden and should not be used`
-	slog.Info("msg", slog.Attr{Value: slog.IntValue(1), Key: `foo_bar`}) // want `"foo_bar" key is forbidden and should not be used`
+	slog.Info("msg", slog.Attr{"foo_bar", slog.IntValue(1)})                  // want `"foo_bar" key is forbidden and should not be used`
+	slog.Info("msg", slog.Attr{snakeKey, slog.IntValue(1)})                   // want `"foo_bar" key is forbidden and should not be used`
+	slog.Info("msg", slog.Attr{Key: "foo_bar"})                               // want `"foo_bar" key is forbidden and should not be used`
+	slog.Info("msg", slog.Attr{Key: snakeKey})                                // want `"foo_bar" key is forbidden and should not be used`
+	slog.Info("msg", slog.Attr{Key: "foo_bar", Value: slog.IntValue(1)})      // want `"foo_bar" key is forbidden and should not be used`
+	slog.Info("msg", slog.Attr{Key: snakeKey, Value: slog.IntValue(1)})       // want `"foo_bar" key is forbidden and should not be used`
+	slog.Info("msg", slog.Attr{Value: slog.IntValue(1), Key: "foo_bar"})      // want `"foo_bar" key is forbidden and should not be used`
+	slog.Info("msg", slog.Attr{Value: slog.IntValue(1), Key: snakeKey})       // want `"foo_bar" key is forbidden and should not be used`
+	slog.Info("msg", slog.Attr{Value: slog.IntValue(1), Key: `foo_bar`})      // want `"foo_bar" key is forbidden and should not be used`
+	slog.With(slog.Attr{"foo_bar", slog.IntValue(1)}).Info("msg")             // want `"foo_bar" key is forbidden and should not be used`
+	slog.With(slog.Attr{snakeKey, slog.IntValue(1)}).Info("msg")              // want `"foo_bar" key is forbidden and should not be used`
+	slog.With(slog.Attr{Key: "foo_bar"}).Info("msg")                          // want `"foo_bar" key is forbidden and should not be used`
+	slog.With(slog.Attr{Key: snakeKey}).Info("msg")                           // want `"foo_bar" key is forbidden and should not be used`
+	slog.With(slog.Attr{Key: "foo_bar", Value: slog.IntValue(1)}).Info("msg") // want `"foo_bar" key is forbidden and should not be used`
+	slog.With(slog.Attr{Key: snakeKey, Value: slog.IntValue(1)}).Info("msg")  // want `"foo_bar" key is forbidden and should not be used`
+	slog.With(slog.Attr{Value: slog.IntValue(1), Key: "foo_bar"}).Info("msg") // want `"foo_bar" key is forbidden and should not be used`
+	slog.With(slog.Attr{Value: slog.IntValue(1), Key: snakeKey}).Info("msg")  // want `"foo_bar" key is forbidden and should not be used`
+	slog.With(slog.Attr{Value: slog.IntValue(1), Key: `foo_bar`}).Info("msg") // want `"foo_bar" key is forbidden and should not be used`
+
 }

--- a/testdata/src/key_naming_case/key_naming_case.go
+++ b/testdata/src/key_naming_case/key_naming_case.go
@@ -1,6 +1,9 @@
 package key_naming_case
 
-import "log/slog"
+import (
+	"context"
+	"log/slog"
+)
 
 const (
 	snakeKey = "foo_bar"
@@ -35,6 +38,37 @@ func tests() {
 	slog.Info("msg", slog.Attr{Key: kebabKey, Value: slog.IntValue(1)})  // want `keys should be written in snake_case`
 	slog.Info("msg", slog.Attr{Value: slog.IntValue(1), Key: "foo-bar"}) // want `keys should be written in snake_case`
 	slog.Info("msg", slog.Attr{Value: slog.IntValue(1), Key: kebabKey})  // want `keys should be written in snake_case`
+
+	// With snake_case key
+	slog.Info("msg")
+	slog.With("foo_bar", 1).Info("msg")
+	slog.With(snakeKey, 1).Info("msg")
+	slog.With(slog.Int("foo_bar", 1)).Info("msg")
+	slog.With(slog.Int(snakeKey, 1)).Info("msg")
+	slog.With(slog.Attr{}).Info("msg")
+	slog.With(slog.Attr{"foo_bar", slog.IntValue(1)}).Info("msg")
+	slog.With(slog.Attr{snakeKey, slog.IntValue(1)}).Info("msg")
+	slog.With(slog.Attr{Key: "foo_bar"}).Info("msg")
+	slog.With(slog.Attr{Key: snakeKey}).Info("msg")
+	slog.With(slog.Attr{Key: "foo_bar", Value: slog.IntValue(1)}).Info("msg")
+	slog.With(slog.Attr{Key: snakeKey, Value: slog.IntValue(1)}).Info("msg")
+	slog.With(slog.Attr{Value: slog.IntValue(1), Key: "foo_bar"}).Info("msg")
+	slog.With(slog.Attr{Value: slog.IntValue(1), Key: snakeKey}).Info("msg")
+
+	slog.With("foo-bar", 1).Info("msg")                                       // want `keys should be written in snake_case`
+	slog.With(kebabKey, 1).Info("msg")                                        // want `keys should be written in snake_case`
+	slog.With(slog.Int("foo-bar", 1)).Info("msg")                             // want `keys should be written in snake_case`
+	slog.With(slog.Int(kebabKey, 1)).Info("msg")                              // want `keys should be written in snake_case`
+	slog.With(slog.Attr{"foo-bar", slog.IntValue(1)}).Info("msg")             // want `keys should be written in snake_case`
+	slog.With(slog.Attr{kebabKey, slog.IntValue(1)}).Info("msg")              // want `keys should be written in snake_case`
+	slog.With(slog.Attr{Key: "foo-bar"}).Info("msg")                          // want `keys should be written in snake_case`
+	slog.With(slog.Attr{Key: kebabKey}).Info("msg")                           // want `keys should be written in snake_case`
+	slog.With(slog.Attr{Key: "foo-bar", Value: slog.IntValue(1)}).Info("msg") // want `keys should be written in snake_case`
+	slog.With(slog.Attr{Key: kebabKey, Value: slog.IntValue(1)}).Info("msg")  // want `keys should be written in snake_case`
+	slog.With(slog.Attr{Value: slog.IntValue(1), Key: "foo-bar"}).Info("msg") // want `keys should be written in snake_case`
+	slog.With(slog.Attr{Value: slog.IntValue(1), Key: kebabKey}).Info("msg")  // want `keys should be written in snake_case`
+
+	slog.LogAttrs(context.TODO(), slog.LevelInfo, "msg", slog.Attr{Value: slog.IntValue(1), Key: kebabKey}) // want `keys should be written in snake_case`
 }
 
 func issue35() {

--- a/testdata/src/kv_only/kv_only.go
+++ b/testdata/src/kv_only/kv_only.go
@@ -6,8 +6,13 @@ func tests() {
 	slog.Info("msg")
 	slog.Info("msg", "foo", 1)
 	slog.Info("msg", "foo", 1, "bar", 2)
+	slog.With("foo", 1).Info("msg")
+	slog.With("foo", 1, "bar", 2).Info("msg")
 
-	slog.Info("msg", slog.Int("foo", 1))                     // want `attributes should not be used`
-	slog.Info("msg", slog.Int("foo", 1), slog.Int("bar", 2)) // want `attributes should not be used`
-	slog.Info("msg", "foo", 1, slog.Int("bar", 2))           // want `attributes should not be used`
+	slog.Info("msg", slog.Int("foo", 1))                          // want `attributes should not be used`
+	slog.Info("msg", slog.Int("foo", 1), slog.Int("bar", 2))      // want `attributes should not be used`
+	slog.Info("msg", "foo", 1, slog.Int("bar", 2))                // want `attributes should not be used`
+	slog.With(slog.Int("foo", 1)).Info("msg")                     // want `attributes should not be used`
+	slog.With(slog.Int("foo", 1), slog.Int("bar", 2)).Info("msg") // want `attributes should not be used`
+	slog.With("foo", 1, slog.Int("bar", 2)).Info("msg")           // want `attributes should not be used`
 }

--- a/testdata/src/no_global_default/no_global_default.go
+++ b/testdata/src/no_global_default/no_global_default.go
@@ -5,6 +5,8 @@ import "log/slog"
 var logger = slog.New(nil)
 
 func tests() {
-	slog.Info("msg") // want `default logger should not be used`
+	slog.Info("msg")          // want `default logger should not be used`
+	slog.With("key", "value") // want `default logger should not be used`
 	logger.Info("msg")
+	logger.With("key", "value")
 }

--- a/testdata/src/no_mixed_args/no_mixed_args.go
+++ b/testdata/src/no_mixed_args/no_mixed_args.go
@@ -14,6 +14,9 @@ func tests() {
 	slog.Info("msg", "foo", 1, "bar", 2)
 	slog.Info("msg", slog.Int("foo", 1))
 	slog.Info("msg", slog.Int("foo", 1), slog.Int("bar", 2))
+	slog.With("foo", 1, "bar", 2).Info("msg")
+	slog.With(slog.Int("foo", 1)).Info("msg")
+	slog.With(slog.Int("foo", 1), slog.Int("bar", 2)).Info("msg")
 
 	slog.Log(ctx, slog.LevelInfo, "msg", "foo", 1, slog.Int("bar", 2)) // want `key-value pairs and attributes should not be mixed`
 	slog.Debug("msg", "foo", 1, slog.Int("bar", 2))                    // want `key-value pairs and attributes should not be mixed`
@@ -24,14 +27,17 @@ func tests() {
 	slog.InfoContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))         // want `key-value pairs and attributes should not be mixed`
 	slog.WarnContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))         // want `key-value pairs and attributes should not be mixed`
 	slog.ErrorContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))        // want `key-value pairs and attributes should not be mixed`
+	slog.With("foo", 1, slog.Int("bar", 2)).ErrorContext(ctx, "msg")   // want `key-value pairs and attributes should not be mixed`
 
-	logger.Log(ctx, slog.LevelInfo, "msg", "foo", 1, slog.Int("bar", 2)) // want `key-value pairs and attributes should not be mixed`
-	logger.Debug("msg", "foo", 1, slog.Int("bar", 2))                    // want `key-value pairs and attributes should not be mixed`
-	logger.Info("msg", "foo", 1, slog.Int("bar", 2))                     // want `key-value pairs and attributes should not be mixed`
-	logger.Warn("msg", "foo", 1, slog.Int("bar", 2))                     // want `key-value pairs and attributes should not be mixed`
-	logger.Error("msg", "foo", 1, slog.Int("bar", 2))                    // want `key-value pairs and attributes should not be mixed`
-	logger.DebugContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))        // want `key-value pairs and attributes should not be mixed`
-	logger.InfoContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))         // want `key-value pairs and attributes should not be mixed`
-	logger.WarnContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))         // want `key-value pairs and attributes should not be mixed`
-	logger.ErrorContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))        // want `key-value pairs and attributes should not be mixed`
+	logger.Log(ctx, slog.LevelInfo, "msg", "foo", 1, slog.Int("bar", 2))         // want `key-value pairs and attributes should not be mixed`
+	logger.Debug("msg", "foo", 1, slog.Int("bar", 2))                            // want `key-value pairs and attributes should not be mixed`
+	logger.Info("msg", "foo", 1, slog.Int("bar", 2))                             // want `key-value pairs and attributes should not be mixed`
+	logger.Warn("msg", "foo", 1, slog.Int("bar", 2))                             // want `key-value pairs and attributes should not be mixed`
+	logger.Error("msg", "foo", 1, slog.Int("bar", 2))                            // want `key-value pairs and attributes should not be mixed`
+	logger.DebugContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))                // want `key-value pairs and attributes should not be mixed`
+	logger.InfoContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))                 // want `key-value pairs and attributes should not be mixed`
+	logger.WarnContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))                 // want `key-value pairs and attributes should not be mixed`
+	logger.ErrorContext(ctx, "msg", "foo", 1, slog.Int("bar", 2))                // want `key-value pairs and attributes should not be mixed`
+	logger.With("foo", 1, slog.Int("bar", 2)).ErrorContext(ctx, "msg")           // want `key-value pairs and attributes should not be mixed`
+	logger.With("foo", 1).ErrorContext(ctx, "msg", "foo", 1, slog.Int("bar", 2)) // want `key-value pairs and attributes should not be mixed`
 }

--- a/testdata/src/no_raw_keys/no_raw_keys.go
+++ b/testdata/src/no_raw_keys/no_raw_keys.go
@@ -26,4 +26,11 @@ func tests() {
 	slog.Info("msg", slog.Attr{Key: "foo"})                          // want `raw keys should not be used`
 	slog.Info("msg", slog.Attr{Key: "foo", Value: slog.IntValue(1)}) // want `raw keys should not be used`
 	slog.Info("msg", slog.Attr{Value: slog.IntValue(1), Key: "foo"}) // want `raw keys should not be used`
+
+	slog.With("foo", 1).Info("msg")                                       // want `raw keys should not be used`
+	slog.With(slog.Int("foo", 1)).Info("msg")                             // want `raw keys should not be used`
+	slog.With(slog.Attr{"foo", slog.IntValue(1)}).Info("msg")             // want `raw keys should not be used`
+	slog.With(slog.Attr{Key: "foo"}).Info("msg")                          // want `raw keys should not be used`
+	slog.With(slog.Attr{Key: "foo", Value: slog.IntValue(1)}).Info("msg") // want `raw keys should not be used`
+	slog.With(slog.Attr{Value: slog.IntValue(1), Key: "foo"}).Info("msg") // want `raw keys should not be used`
 }


### PR DESCRIPTION
This PR enforces the lint rules to `With` and `LogAttrs` functions that are enforced to arguments in other logger funcs.

Fixes https://github.com/go-simpler/sloglint/issues/38