### PR TITLE
fix: do not check `static-msg` for `With` functions

### DIFF
--- a/sloglint.go
+++ b/sloglint.go
@@ -223,7 +223,8 @@ func visit(pass *analysis.Pass, opts *Options, node ast.Node, stack []ast.Node) 
 	}
 
 	msgPos := funcInfo.argsPos - 1
-	if opts.StaticMsg && !isStaticMsg(call.Args[msgPos]) {
+	// NOTE: "With" functions have no message argument and must be skipped.
+	if opts.StaticMsg && msgPos >= 0 && !isStaticMsg(call.Args[msgPos]) {
 		pass.Reportf(call.Pos(), "message should be a string literal or a constant")
 	}
 

--- a/testdata/src/context_only_scope/context_only_scope.go
+++ b/testdata/src/context_only_scope/context_only_scope.go
@@ -9,6 +9,9 @@ func tests(ctx context.Context) {
 	slog.Info("msg") // want `InfoContext should be used instead`
 	slog.InfoContext(ctx, "msg")
 
+	slog.With("key", "value").Info("msg") // want `InfoContext should be used instead`
+	slog.With("key", "value").InfoContext(ctx, "msg")
+
 	if true {
 		slog.Info("msg") // want `InfoContext should be used instead`
 		slog.InfoContext(ctx, "msg")

--- a/testdata/src/no_global_all/no_global_all.go
+++ b/testdata/src/no_global_all/no_global_all.go
@@ -5,6 +5,8 @@ import "log/slog"
 var logger = slog.New(nil)
 
 func tests() {
-	slog.Info("msg")   // want `global logger should not be used`
-	logger.Info("msg") // want `global logger should not be used`
+	slog.Info("msg")            // want `global logger should not be used`
+	logger.Info("msg")          // want `global logger should not be used`
+	slog.With("key", "value")   // want `global logger should not be used`
+	logger.With("key", "value") // want `global logger should not be used`
 }

--- a/testdata/src/static_msg/static_msg.go
+++ b/testdata/src/static_msg/static_msg.go
@@ -20,10 +20,12 @@ func tests() {
 	slog.Info(constMsg)
 	slog.InfoContext(ctx, constMsg)
 	slog.Log(ctx, slog.LevelInfo, constMsg)
+	slog.With("key", "value").Info("msg")
 
-	slog.Info(fmt.Sprintf("msg"))                     // want `message should be a string literal or a constant`
-	slog.InfoContext(ctx, fmt.Sprintf("msg"))         // want `message should be a string literal or a constant`
-	slog.Log(ctx, slog.LevelInfo, fmt.Sprintf("msg")) // want `message should be a string literal or a constant`
+	slog.Info(fmt.Sprintf("msg"))                      // want `message should be a string literal or a constant`
+	slog.InfoContext(ctx, fmt.Sprintf("msg"))          // want `message should be a string literal or a constant`
+	slog.Log(ctx, slog.LevelInfo, fmt.Sprintf("msg"))  // want `message should be a string literal or a constant`
+	slog.With("key", "value").Info(fmt.Sprintf("msg")) // want `message should be a string literal or a constant`
 
 	slog.Info(varMsg)                     // want `message should be a string literal or a constant`
 	slog.InfoContext(ctx, varMsg)         // want `message should be a string literal or a constant`


### PR DESCRIPTION
In `With` functions, `msgPos := funcInfo.argsPos - 1` resolves to `-1` because these functions do not have a message argument. This causes a panic when `static-msg` is enabled. Added a check to ensure `msgPos` is valid before proceeding.

Fixes #46