### PR TITLE
fix(no-raw-keys): do not report constants from other packages

### DIFF
--- a/sloglint.go
+++ b/sloglint.go
@@ -266,18 +266,23 @@ func visit(pass *analysis.Pass, opts *Options, node ast.Node, stack []ast.Node) 
 	if opts.NoRawKeys {
 		forEachKey(pass.TypesInfo, keys, attrs, func(key ast.Expr) {
 			if pkgIdent, ok := key.(*ast.SelectorExpr); ok {
-				// This is a package selector; e.g. slog.String.
+				// This is a package selector; e.g. logging.KeyError
 				key = pkgIdent.Sel
 			}
 
+			// Check if the key is a constant.
 			if ident, ok := key.(*ast.Ident); ok {
+				// Check if the constant is defined in the same package.
 				obj := pass.TypesInfo.ObjectOf(ident)
 				if obj == nil || obj.Pkg() == nil || obj.Type() == nil {
+					// Object is not found or not fully resolved.
 					pass.Reportf(call.Pos(), "raw keys should not be used")
 				} else if _, ok := obj.(*types.Const); !ok {
+					// Object is not a constant.
 					pass.Reportf(call.Pos(), "raw keys should not be used")
 				}
 			} else {
+				// Key is not an identifier.
 				pass.Reportf(call.Pos(), "raw keys should not be used")
 			}
 		})

--- a/testdata/src/no_raw_keys/keys/consts.go
+++ b/testdata/src/no_raw_keys/keys/consts.go
@@ -1,5 +1,0 @@
-package keys
-
-const (
-	FooPkgConst = "foo_pkg_const"
-)

--- a/testdata/src/no_raw_keys/keys/consts.go
+++ b/testdata/src/no_raw_keys/keys/consts.go
@@ -1,0 +1,5 @@
+package keys
+
+const (
+	FooPkgConst = "foo_pkg_const"
+)

--- a/testdata/src/no_raw_keys/keys/keys.go
+++ b/testdata/src/no_raw_keys/keys/keys.go
@@ -1,0 +1,3 @@
+package keys
+
+const Foo = "foo"

--- a/testdata/src/no_raw_keys/no_raw_keys.go
+++ b/testdata/src/no_raw_keys/no_raw_keys.go
@@ -1,6 +1,9 @@
 package no_raw_keys
 
-import "log/slog"
+import (
+	"log/slog"
+	"no_raw_keys/keys"
+)
 
 const foo = "foo"
 
@@ -11,6 +14,7 @@ func Foo(value int) slog.Attr {
 func tests() {
 	slog.Info("msg")
 	slog.Info("msg", foo, 1)
+	slog.Info("msg", keys.Foo, 1)
 	slog.Info("msg", Foo(1))
 	slog.Info("msg", slog.Int(foo, 1))
 	slog.Info("msg", slog.Attr{})

--- a/testdata/src/no_raw_keys/no_raw_keys.go
+++ b/testdata/src/no_raw_keys/no_raw_keys.go
@@ -1,6 +1,10 @@
 package no_raw_keys
 
-import "log/slog"
+import (
+	"log/slog"
+
+	"go-simpler.org/sloglint/testdata/src/no_raw_keys/keys"
+)
 
 const foo = "foo"
 
@@ -11,6 +15,7 @@ func Foo(value int) slog.Attr {
 func tests() {
 	slog.Info("msg")
 	slog.Info("msg", foo, 1)
+	slog.Info("msg", keys.FooPkgConst, 1)
 	slog.Info("msg", Foo(1))
 	slog.Info("msg", slog.Int(foo, 1))
 	slog.Info("msg", slog.Attr{})

--- a/testdata/src/no_raw_keys/no_raw_keys.go
+++ b/testdata/src/no_raw_keys/no_raw_keys.go
@@ -1,10 +1,6 @@
 package no_raw_keys
 
-import (
-	"log/slog"
-
-	"go-simpler.org/sloglint/testdata/src/no_raw_keys/keys"
-)
+import "log/slog"
 
 const foo = "foo"
 
@@ -15,7 +11,6 @@ func Foo(value int) slog.Attr {
 func tests() {
 	slog.Info("msg")
 	slog.Info("msg", foo, 1)
-	slog.Info("msg", keys.FooPkgConst, 1)
 	slog.Info("msg", Foo(1))
 	slog.Info("msg", slog.Int(foo, 1))
 	slog.Info("msg", slog.Attr{})


### PR DESCRIPTION
Closes #66 

This pull request includes changes to improve the handling of raw keys in the `sloglint` package. The most important changes include enhancing the key checking logic, adding new constant definitions, and modifying test cases to use the new constants.

Improvements to key checking logic:

* [`sloglint.go`](diffhunk://#diff-206325316580eabf2114fa66e05a5049791c191920c4ca4d2cd7862d5f7434e9L268-R285): Enhanced the logic in the `visit` function to handle package selectors and ensure that keys are constants defined within any package.

Additions to constant definitions:

* [`testdata/src/no_raw_keys/keys/consts.go`](diffhunk://#diff-36d7eac90760c0a1bc60d3ef65f985de2b3717ea590d95efa7e6c74c4b2d5ce0R1-R5): Added a new file to define package-level constants.

Updates to test cases:

* [`testdata/src/no_raw_keys/no_raw_keys.go`](diffhunk://#diff-bd3f5ed3cbbb4a9cf09dc382052d2b0889f55369fd96242a4554a0921de1dc8fL3-R7): Modified imports to include the new constants and updated test cases to use these constants. [[1]](diffhunk://#diff-bd3f5ed3cbbb4a9cf09dc382052d2b0889f55369fd96242a4554a0921de1dc8fL3-R7) [[2]](diffhunk://#diff-bd3f5ed3cbbb4a9cf09dc382052d2b0889f55369fd96242a4554a0921de1dc8fR18)

## Testing

The new test case does not trigger the error

![image](https://github.com/user-attachments/assets/0fda70b3-0cda-4bb4-866b-d31d6378a6b7)

