### PR TITLE
chore: downgrade minimum Go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module go-simpler.org/sloglint
 
-go 1.23
+go 1.22.0
+
+toolchain go1.23.0
 
 require (
 	github.com/ettle/strcase v0.2.0


### PR DESCRIPTION
The minimum Go version is a hard requirement for library consumers.

The Go version inside `toolchain` defined the Go version used to compile and doesn't affect lib consumers.

The minimum Go version can be either a "family name" (e.g. `1.22`) or a "release name" (e.g. `1.22.0`). It's important not to update the patch element to avoid forcing lib consumers to also update to this patched version.

The minimum Go version should only be used to define the minimum language version used to write and compile a module.

The toolchain version must be a prefixed "release name" (e.g. `go1.22.0`).

Related to https://github.com/go-simpler/sloglint/issues/62#issuecomment-2645872293
Related to #68
