### PR TITLE
chore: display Go version used to build

### DIFF
--- a/cmd/sloglint/main.go
+++ b/cmd/sloglint/main.go
@@ -23,7 +23,7 @@ type versionFlag struct{}
 func (versionFlag) String() string   { return "" }
 func (versionFlag) IsBoolFlag() bool { return true }
 func (versionFlag) Set(string) error {
-	fmt.Printf("sloglint version %s %s/%s\n", version, runtime.GOOS, runtime.GOARCH)
+	fmt.Printf("sloglint version %s %s/%s (built with %s)\n", version, runtime.GOOS, runtime.GOARCH, runtime.Version())
 	os.Exit(0)
 	return nil
 }


### PR DESCRIPTION
```console
$ go run ./cmd/sloglint/ -V
sloglint version dev linux/amd64 (built with go1.23.6)
```

Related to https://github.com/go-simpler/sloglint/issues/62#issuecomment-2645872293
